### PR TITLE
chore: upgrade Calcit and retire compact lookup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 
-calcit.cirru -diff linguist-generated
 yarn.lock -diff linguist-generated
 
 Cargo.lock -diff linguist-generated

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -17,7 +17,7 @@ jobs:
         registry-url: https://registry.npmjs.org/
         cache: yarn
 
-    - uses: calcit-lang/setup-cr@0.0.9
+    - uses: calcit-lang/setup-calcit@v1
 
     - run: caps --ci && yarn && yarn compile-server && yarn compile-page && yarn release-page
 

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -17,7 +17,7 @@ jobs:
         registry-url: https://registry.npmjs.org/
         cache: yarn
 
-    - uses: calcit-lang/setup-calcita2e53ae41e4f0d5856a424b9ed4470d90ea6876@v1
+    - uses: calcit-lang/setup-calcit@6a2e53ae41e4f0d5856a424b9ed4470d90ea6876
 
     - run: caps --ci && yarn && yarn compile-server && yarn compile-page && yarn release-page
 

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -17,7 +17,7 @@ jobs:
         registry-url: https://registry.npmjs.org/
         cache: yarn
 
-    - uses: calcit-lang/setup-calcit@v1
+    - uses: calcit-lang/setup-calcita2e53ae41e4f0d5856a424b9ed4470d90ea6876@v1
 
     - run: caps --ci && yarn && yarn compile-server && yarn compile-page && yarn release-page
 

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -17,7 +17,7 @@ jobs:
         node-version: 24
         cache: yarn
 
-    - uses: calcit-lang/setup-cr@0.0.9
+    - uses: calcit-lang/setup-calcit@v1
 
     - run: caps --ci && yarn && yarn compile-server && yarn compile-page && yarn release-page
 

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -17,7 +17,7 @@ jobs:
         node-version: 24
         cache: yarn
 
-    - uses: calcit-lang/setup-calcita2e53ae41e4f0d5856a424b9ed4470d90ea6876@v1
+    - uses: calcit-lang/setup-calcit@6a2e53ae41e4f0d5856a424b9ed4470d90ea6876
 
     - run: caps --ci && yarn && yarn compile-server && yarn compile-page && yarn release-page
 

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -17,7 +17,7 @@ jobs:
         node-version: 24
         cache: yarn
 
-    - uses: calcit-lang/setup-calcit@v1
+    - uses: calcit-lang/setup-calcita2e53ae41e4f0d5856a424b9ed4470d90ea6876@v1
 
     - run: caps --ci && yarn && yarn compile-server && yarn compile-page && yarn release-page
 

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1294,7 +1294,7 @@
                     run-command! "|cat release.edn | grep :version" d! $ {}
                       :on-finish $ fn ()
                   (pos? (.!indexOf files |calcit.cirru))
-                    run-command! "|cat calcit.cirru | grep version\\n" d! $ {}
+                    run-command! "|cat calcit.cirru | grep version" d! $ {}
                       :on-finish $ fn ()
                   (some? maybe-nimble)
                     run-command! (str "|cat " maybe-nimble "| | grep version") d! $ {}
@@ -1437,7 +1437,7 @@
                     path/join
                       dirname $ fileURLToPath js/import.meta.url
                       , |../package.json
-                  :: JsObject
+                  , JsObject
                 version $ unsafe-coerce (.-version pkg) String
               ->
                 unsafe-coerce (.-name pkg) JsObject

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,5 +1,5 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |app)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'app.client/main!) (:mode :native) (:reload-fn 'app.client/reload!)
       :feature-policy $ {}
@@ -1293,8 +1293,8 @@
                   (pos? (.!indexOf files |release.edn))
                     run-command! "|cat release.edn | grep :version" d! $ {}
                       :on-finish $ fn ()
-                  (pos? (.!indexOf files |compact.cirru))
-                    run-command! "|cat compact.cirru | grep version\n" d! $ {}
+                  (pos? (.!indexOf files |calcit.cirru))
+                    run-command! "|cat calcit.cirru | grep version\\n" d! $ {}
                       :on-finish $ fn ()
                   (some? maybe-nimble)
                     run-command! (str "|cat " maybe-nimble "| | grep version") d! $ {}
@@ -1437,7 +1437,7 @@
                     path/join
                       dirname $ fileURLToPath js/import.meta.url
                       , |../package.json
-                  JsObject
+                  :: JsObject
                 version $ unsafe-coerce (.-version pkg) String
               ->
                 unsafe-coerce (.-name pkg) JsObject

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,16 +1,16 @@
 
-{} (:calcit-version |0.13.27)
+{} (:calcit-version |0.13.29)
   :version |0.3.0
-  :dependencies $ {} (|Cumulo/cumulo-reel.calcit |main)
-    |Cumulo/cumulo-util.calcit |main
-    |Respo/alerts.calcit |main
-    |Respo/respo-feather.calcit |main
-    |Respo/respo-markdown.calcit |main
-    |Respo/respo-message.calcit |main
-    |Respo/respo-ui.calcit |main
+  :dependencies $ {} (|Cumulo/cumulo-reel.calcit |0.0.24)
+    |Cumulo/cumulo-util.calcit |0.0.13
+    |Respo/alerts.calcit |0.10.19
+    |Respo/respo-feather.calcit |0.4.4
+    |Respo/respo-markdown.calcit |0.4.22
+    |Respo/respo-message.calcit |0.0.13
+    |Respo/respo-ui.calcit |0.7.9
     |Respo/respo.calcit |0.16.78
     |calcit-lang/js-ffi |0.1.9
-    |calcit-lang/lilac |main
-    |calcit-lang/memof |main
-    |calcit-lang/recollect |main
-    |mvc-works/ws-edn.calcit |main
+    |calcit-lang/lilac |0.5.2
+    |calcit-lang/memof |0.0.26
+    |calcit-lang/recollect |0.0.30
+    |mvc-works/ws-edn.calcit |0.0.16

--- a/history/2026082222-upgrade-calcit-01329.md
+++ b/history/2026082222-upgrade-calcit-01329.md
@@ -1,0 +1,7 @@
+# 2026082222 Upgrade Calcit and retire compact-file lookup
+
+- Updated Calcit and @calcit/procs to 0.13.29.
+- Pinned dependencies to formal releases instead of main branches.
+- Replaced setup-cr and cr commands with setup-calcit and calcit.
+- Updated source version lookup from compact.cirru to calcit.cirru.
+- Removed the linguist-generated rule hiding calcit.cirru.

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "rebase-hell": "./bin.js"
   },
   "scripts": {
-    "compile-server": "cr --entry server js",
-    "compile-page": "cr --emit-path out-page js",
+    "compile-server": "calcit calcit.cirru --entry server js",
+    "compile-page": "calcit calcit.cirru --emit-path out-page js",
     "release-page": "vite build --base=./",
-    "watch-page": "cr --emit-path out-page/ js",
-    "watch-server": "cr --entry server js"
+    "watch-page": "calcit calcit.cirru --emit-path out-page/ js",
+    "watch-server": "calcit calcit.cirru --entry server js"
   },
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
   "author": "jiyinyiyong",
   "license": "MIT",
   "dependencies": {
-    "@calcit/procs": "^0.13.27",
+    "@calcit/procs": "^0.13.29",
     "axios": "^1.9.0",
     "chalk": "^5.4.1",
     "dayjs": "^1.11.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@calcit/procs@^0.13.27":
-  version "0.13.27"
-  resolved "https://registry.npmmirror.com/@calcit/procs/-/procs-0.13.27.tgz#bb41d505afcd3f3b91f277353768373f5fbb7454"
-  integrity sha512-aw5xwZBYL1ndpoiqaFmRw88xVyonnSIvZC6O3k1vuPZBul4R5qNicm/U3vgBFrMiNciWCDT0hklxu9IcGWoMBw==
+"@calcit/procs@^0.13.29":
+  version "0.13.29"
+  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.13.29.tgz#c9f78cbdc010a9d8a3ee5a8b2f0a8c696f3ae05f"
+  integrity sha512-o05P84UyZzdEN1Flm5M8U4lvNMUrqI2P4+z1z+H+fNrQ+VsrIie3uQlB2ZQuk/Ilhs5WsrESZL9AkI+ZzkgOlw==
   dependencies:
     "@calcit/ternary-tree" "0.0.26"
     "@cirru/parser.ts" "^0.0.9"


### PR DESCRIPTION
Synced latest main before changing the project. Updated Calcit and @calcit/procs to 0.13.29, migrated setup-calcit and calcit commands, and removed the hidden-source treatment where applicable. Local Calcit check-only and lockfile validation pass.